### PR TITLE
Fix detection of Auth mechanisms.

### DIFF
--- a/php/xmpp-prebind-php/lib/XmppPrebind.php
+++ b/php/xmpp-prebind-php/lib/XmppPrebind.php
@@ -137,13 +137,8 @@ class XmppPrebind {
 		}
 		$this->debug($this->sid, 'sid');
 
-		$child = $body->firstChild->firstChild;
-		if (is_object($child)) {
-			$mechanisms = $child->getElementsByTagName('mechanism');
-		} else {
-			throw new Exception('Invalid response');
-		}
-
+		$mechanisms = $body->getElementsByTagName('mechanism');
+		
 		foreach ($mechanisms as $value) {
 			$this->mechanisms[] = $value->nodeValue;
 		}


### PR DESCRIPTION
 <mechanisms> is not neccessarily a child of <auth> (http://xmpp.org/rfcs/rfc3920.html#tls)

Pre-Binding did not reliably work for me with Prosody 0.9.4.
